### PR TITLE
Simplify building for RPI and add ibexif-dev lib

### DIFF
--- a/.env
+++ b/.env
@@ -7,6 +7,7 @@ DESCRIPTION=@maxvoltar's minimalistic, self-hosted photo stream.
 BASEURL=
 URL=https://maxvoltar.photo/ # must end with / or links will be broken
 SHOW_OFFICIAL_GITHUB=1
+PHOTO_PATH=./photos
 #TWITTER_USERNAME=maxvoltar
 #GITHUB_USERNAME=maxvoltar
 #INSTAGRAM_USERNAME=maxvoltar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM ruby:3.0.1-alpine3.13
-
+ARG  BASE_IMAGE=ruby:3.0.1-alpine3.13
+FROM ${BASE_IMAGE}
 ENV VIPSVER 8.11.3
-RUN apk update && apk upgrade &&\
-    apk add --update --no-cache build-base glib-dev expat-dev tiff-dev jpeg-dev libgsf-dev git rsync lftp openssh &&\
+RUN apk update && apk upgrade && \
+    apk add --update --no-cache build-base glib-dev expat-dev tiff-dev jpeg-dev libgsf-dev git rsync lftp openssh libexif-dev &&\
     rm -rf /var/cache/apk/*
 
 RUN wget -O ./vips-$VIPSVER.tar.gz https://github.com/libvips/libvips/releases/download/v$VIPSVER/vips-$VIPSVER.tar.gz
@@ -19,4 +19,5 @@ RUN ruby -v && gem install bundler jekyll &&\
 
 EXPOSE 4000
 
-ENTRYPOINT bundle exec jekyll serve --host 0.0.0.0
+ARG DEBUG=false
+ENTRYPOINT DEBUG=${DEBUG} bundle exec jekyll serve --host 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ docker-compose up -d
 
 The `photos` folder can be mounted as a volume. Make sure to put your photos in a folder called `original`.
 
+#### Using docker on raspberry pi:
+
+Prerequisites : docker and docker-compose are installed on RPI
+
+In docker-compose.yml comment `image` section, uncomment `build` section, and setup `BASE_REPO` arg to `arm32v6/ruby:3.0.1-alpine3.12`.
+
+Then `docker-compose build`
+
+Then `docker-compose up -d`
+
 ### Manually
 
 Grab the latest version from the [release](https://github.com/waschinski/photo-stream/releases) page and extract it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,21 +4,26 @@ services:
     container_name: photo-stream
     image: waschinski/photo-stream:latest
     #To build from source, comment previous line and uncomment next line
-    #build: .
+    # build:
+    #   context: .
+    #   args:
+    ##     - DEBUG=true
+    ##     - BASE_IMAGE=arm32v6/ruby:3.0.1-alpine3.12 # arm base image for RPI
     environment:
-      - TITLE=maxvoltar.photo
-      - EMAIL=tim@maxvoltar.be
-      - AUTHOR_NAME=Tim Van Damme
-      - AUTHOR_EMAIL=tim@maxvoltar.be
-      - AUTHOR_WEBSITE=https://maxvoltar.com
-      - DESCRIPTION=@maxvoltar's minimalistic, self-hosted photo stream.
-      - BASEURL=
-      - URL=https://maxvoltar.photo/
-      - SHOW_OFFICIAL_GITHUB=1
+      - TITLE=${TITLE}
+      - EMAIL=${EMAIL}
+      - AUTHOR_NAME=${AUTHOR_NAME}
+      - AUTHOR_EMAIL=${AUTHOR_EMAIL}
+      - AUTHOR_WEBSITE=${AUTHOR_WEBSITE}
+      - DESCRIPTION=${DESCRIPTION}
+      - BASEURL=${BASEURL}
+      - URL=${URL}
+      - SHOW_OFFICIAL_GITHUB=${SHOW_OFFICIAL_GITHUB}
+      - TWITTER_USERNAME=${TWITTER_USERNAME}
+      - INSTAGRAM_USERNAME=${INSTAGRAM_USERNAME}
     volumes:
-      - photos:/photo-stream/photos
+      - ${PHOTO_PATH}:/photo-stream/photos/original
+    env_file: .env
     ports:
       - "4000:4000"
     restart: unless-stopped
-volumes:
-  photos:


### PR DESCRIPTION
Add ibexif-dev to fix https://github.com/waschinski/photo-stream/issues/7 
Move to docker build arguments base image for easy replace it when building for RPI
Move to docker build arguments DEBUG run option
Use environment variables from .env file