### PR TITLE
Added VAGRANT_DISABLE_RESOLV_REPLACE=1 to allow building on macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG  BASE_IMAGE=ruby:3.0.1-alpine3.13
 FROM ${BASE_IMAGE}
 ENV VIPSVER 8.11.3
+ENV VAGRANT_DISABLE_RESOLV_REPLACE=1
 RUN apk update && apk upgrade && \
     apk add --update --no-cache build-base glib-dev expat-dev tiff-dev jpeg-dev libgsf-dev git rsync lftp openssh libexif-dev &&\
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
When building on macOS you can't use the normal libc DNS resolver, and this means that building this container on macOS fails at the point where gems need to be installed.

I therefore added the VAGRANT_DISABLE_RESOLV_REPLACE=1 flag so that Ruby Resolv is used during build instead.