### PR TITLE
Option to download original, full-res images

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,7 @@ BASEURL=
 URL=https://maxvoltar.photo/
 SHOW_OFFICIAL_GITHUB=1
 ALLOW_ORDER_SORT_CHANGE=1
+ALLOW_ORIGINAL_DOWNLOAD=0
 PHOTO_PATH=./photos
 # leave the following blank to disable
 TWITTER_USERNAME=

--- a/_includes/photo.html
+++ b/_includes/photo.html
@@ -32,10 +32,18 @@
             <span>Next</span>
         </a>
     {% endunless %}
+    {% if site.env.ALLOW_ORIGINAL_DOWNLOAD == "1" %}
+        <a href="{{ image.path }}" download="{{ safe_name }}" class="next download" title="Download this image"><span>Download</span></a>
+    {% endif %}
 
-    <!-- <ul class="meta">
-    <li>{{ image_path | exif: 'model'}}</li>
-    <li>{{ image_path | exif: 'exposure_time.to_s'}}</li>
-    <li><span class="aperture"><em>f</em>/</span>{{ image_path | exif: 'f_number.to_f'}}</li>
-    </ul> -->
+    <ul class="meta">
+        <!--
+        <li>{{ image_path | exif: 'model'}}</li>
+        <li>{{ image_path | exif: 'exposure_time.to_s'}}</li>
+        <li><span class="aperture"><em>f</em>/</span>{{ image_path | exif: 'f_number.to_f'}}</li>
+        -->
+        {% if site.env.ALLOW_ORIGINAL_DOWNLOAD == "1" %}
+            <li><a href="{{ image.path }}" download="{{ safe_name }}" class="download" title="Download this image">Download</a></li>
+        {% endif %}
+    </ul>
 </li>

--- a/_plugins/destroy_originals.rb
+++ b/_plugins/destroy_originals.rb
@@ -9,14 +9,17 @@ module Jekyll
     end
 
     def self.destroy
-      directories = jekyll_config["image_processing"].each_with_object([]) do |(size, size_options), array|
-        directory = File.join(jekyll_config["destination"], size_options["source"])
-        if directory != jekyll_config["destination"]
-          array.push(directory)
+      # remove the original files when downloads are disabled
+      unless jekyll_config["env"]["ALLOW_ORIGINAL_DOWNLOAD"] == "1"
+        directories = jekyll_config["image_processing"].each_with_object([]) do |(size, size_options), array|
+          directory = File.join(jekyll_config["destination"], size_options["source"])
+          if directory != jekyll_config["destination"]
+            array.push(directory)
+          end
         end
-      end
-      directories.each do |directory|
-        FileUtils.rm_f(Dir.glob("#{directory}/*.[jJ][pP]*[gG]"))
+        directories.each do |directory|
+          FileUtils.rm_f(Dir.glob("#{directory}/*.[jJ][pP]*[gG]"))
+        end
       end
     end
   end

--- a/css/master.scss
+++ b/css/master.scss
@@ -104,6 +104,17 @@ body {
 			outline-color: #000;
 		}
 
+		&:focus,
+		&:hover {
+			.meta .download {
+			   visibility: visible;
+		   }
+
+		   .open {
+				background-color: rgba(0, 0, 0, .25);
+		   }
+		}
+
 		img {
 			max-height: 100%;
 			min-width: 100%;
@@ -209,6 +220,22 @@ body {
 		
 			li {
 				margin-right: 12px;
+
+				.download {
+					@include button;
+					visibility: hidden;
+					background-color: rgba(200, 200, 200, .5);
+					background-image: url(../img/icon-download.svg);
+
+					&:focus,
+					&:hover {
+						background-color: rgba(200, 200, 200, .75);
+					}
+
+					&:active {
+						background-color: rgba(200, 200, 200, 1);
+					}
+				}
 			}
 		}
 		
@@ -267,6 +294,23 @@ body {
 			.previous,
 			.next {
 				display: flex;
+
+				&.download {
+					height: 75px;
+					
+					span {
+						background-image: url(../img/icon-download.svg);
+
+						&:focus,
+						&:hover {
+							background-color: rgba(200, 200, 200, .5);
+						}
+
+						&:active {
+							background-color: rgba(200, 200, 200, .75);
+						}
+					}
+				}
 			}
 		}
 	}
@@ -424,6 +468,14 @@ body {
 			
 			.next {
 				cursor: e-resize;
+			}
+
+			.meta {
+				li {
+					.download {
+						visibility: visible;
+					}
+				}
 			}
 		}
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - SHOW_OFFICIAL_GITHUB=${SHOW_OFFICIAL_GITHUB}
       - TWITTER_USERNAME=${TWITTER_USERNAME}
       - INSTAGRAM_USERNAME=${INSTAGRAM_USERNAME}
+      - ALLOW_ORIGINAL_DOWNLOAD=${ALLOW_ORIGINAL_DOWNLOAD}
     volumes:
       - ${PHOTO_PATH}:/photo-stream/photos/original
     env_file: .env

--- a/img/icon-download.svg
+++ b/img/icon-download.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" id="Icon/Download">
+    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+    <polyline points="7 10 12 15 17 10"></polyline>
+    <line x1="12" y1="15" x2="12" y2="3"></line>
+</svg>


### PR DESCRIPTION
I implemented an option to make the original image files downloadable at full resolution:

![Screenshot 2022-05-03 172545](https://user-images.githubusercontent.com/45766222/166485486-a45f11f8-6b0d-404a-a05d-7dcbf659350d.png)

![Screenshot 2022-05-03 172443](https://user-images.githubusercontent.com/45766222/166485377-3c64235c-1f19-4366-b749-8f0ba7a6c893.png)

I created this to be able to distribute photos I took at a family event to all the participants. This way everyone could easily choose the photos they liked and download them at original quality, which saved me from having to transfer large files to individuals one by one.

This feature might also appeal to professional photographers looking to host their own delivery platform so they don't have to rely on paid services like [Pixieset](https://pixieset.com).

The feature is off by default and can be enabled by setting the `ALLOW_ORIGINAL_DOWNLOAD` environment variable to `1`. In the gallery view, a download button will show up in the bottom right corner of a hovered image. In single-photo view, the download button is permanently visible in the top right corner.

Maybe this is outside the scope of this project (in which case, I don't mind if it doesn't get merged), but I thought that others might find this useful too.