### PR TITLE
Option to prevent crawler / smaller fixes

### DIFF
--- a/.env
+++ b/.env
@@ -10,6 +10,7 @@ URL=https://maxvoltar.photo/
 SHOW_OFFICIAL_GITHUB=1
 ALLOW_ORDER_SORT_CHANGE=1
 ALLOW_ORIGINAL_DOWNLOAD=0
+ALLOW_INDEXING=1
 PHOTO_PATH=./photos
 # leave the following blank to disable
 TWITTER_USERNAME=

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ First thing you want to do is edit a couple of things in `/.env`:
 - `SHOW_OFFICIAL_GITHUB`: Set to either `1` or `0` to enable or disable showing the link to the official github repository
 - `ALLOW_ORDER_SORT_CHANGE`: Set this to `1` to allow users to reverse the sort order of the photos
 - `ALLOW_ORIGINAL_DOWNLOAD`: Set this to `1` to allow users to download the photos in their original size
-- `ALLOW_INDEXING`: Set this to `0` to prevent crawlers form indexing your photo stream by adding meta tag `robots`. Defaults to `1`.
+- `ALLOW_INDEXING`: Set this to `0` to prevent crawlers from indexing your photo stream by adding meta tag `robots`. Defaults to `1`.
 - `TWITTER_USERNAME`: Your Twitter username or remove/comment this line
 - `GITHUB_USERNAME`: Your Github username or remove/comment this line
 - `INSTAGRAM_USERNAME`: Your Instagram username or remove/comment this line

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Photo Stream is a simpler home for your photos initially created by [@maxvoltar]
 - Keyboard shortcuts
 - Unique URL's for photos
 - RSS feed (Which you can plug into [IFTTT](https://ifttt.com) and set up auto-posting to most social networks, like [@maxvoltar](https://github.com/maxvoltar) has done [here](https://twitter.com/maxvoltar_photo). Make sure you select "Post a tweet with image" when setting it up to embed the photo.)
-- Drag, drop, commit workflow ([learn more about how to add photos to your stream](https://github.com/maxvoltar/photo-stream#how-to-use))
+- Drag, drop, commit workflow ([learn more about how to add photos to your stream](#how-to-use))
 - Optimized light and dark themes (auto-enabled depending on your OS preferences)
 - Optional: Links to your social networks
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ First thing you want to do is edit a couple of things in `/.env`:
 - `SHOW_OFFICIAL_GITHUB`: Set to either `1` or `0` to enable or disable showing the link to the official github repository
 - `ALLOW_ORDER_SORT_CHANGE`: Set this to `1` to allow users to reverse the sort order of the photos
 - `ALLOW_ORIGINAL_DOWNLOAD`: Set this to `1` to allow users to download the photos in their original size
+- `ALLOW_INDEXING`: Set this to `0` to prevent crawlers form indexing your photo stream by adding meta tag `robots`. Defaults to `1`.
 - `TWITTER_USERNAME`: Your Twitter username or remove/comment this line
 - `GITHUB_USERNAME`: Your Github username or remove/comment this line
 - `INSTAGRAM_USERNAME`: Your Instagram username or remove/comment this line

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,9 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+	{% if site.env.ALLOW_INDEXING == "0" %}
+	<meta name="robots" content="noindex" />
+	{% endif %}
 	<title data-title="{{ site.env.TITLE }}">{{ page.title | default: site.env.TITLE }}</title>
 	<link rel="alternate" type="application/rss+xml" title="RSS Feed" href="{{ site.env.URL }}feed.xml">
 	<meta property="og:title" content="{{ page.title | default: site.env.TITLE }}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
 	<link rel="alternate" type="application/rss+xml" title="RSS Feed" href="{{ site.env.URL }}feed.xml">
 	<meta property="og:title" content="{{ page.title | default: site.env.TITLE }}">
 	<meta property="og:type" content="website">
-	<meta property="og:url" content="{{ page.url | absolute_url }}">
+	<meta property="og:url" content="{{ site.env.URL }}">
 	<meta property="og:image" content="{{ site.env.URL }}{{ page.images[0].name | uri_escape | processed_path: 'large' | default: 'social-preview.png' }}">
 	<meta property="og:site_name" content="{{ site.env.TITLE }}">
 	<meta property="og:description" content="{{ site.env.DESCRIPTION }}">

--- a/feed.xml
+++ b/feed.xml
@@ -8,13 +8,13 @@
 	<link href="{{ site.env.URL }}" rel="alternate" type="text/html"/>
 	<updated>{{ site.time | date_to_xmlschema }}</updated>
 	<id>{{ site.time | date_to_xmlschema }}</id>
-	<title type="html">{{ site.env.TITLE}}</title>
-	<subtitle>{{ site.env.DESCRIPTION }}</subtitle>
+	<title type="html"><![CDATA[{{ site.env.TITLE}}]]></title>
+	<subtitle><![CDATA[{{ site.env.DESCRIPTION }}]]></subtitle>
 
 	{% if site.env.AUTHOR_NAME or site.env.AUTHOR_EMAIL or site.env.AUTHOR_WEBSITE %}
 		<author>
 			{% if site.env.AUTHOR_NAME %}
-				<name>{{ site.env.AUTHOR_NAME }}</name>
+				<name><![CDATA[{{ site.env.AUTHOR_NAME }}]]></name>
 			{% endif %}
 			{% if site.env.AUTHOR_EMAIL %}
 				<email>{{ site.env.AUTHOR_EMAIL }}</email>
@@ -40,7 +40,7 @@
 			{% if site.env.AUTHOR_NAME %}
 				<author>
 					{% if site.env.AUTHOR_NAME %}
-						<name>{{ site.env.AUTHOR_NAME }}</name>
+						<name><![CDATA[{{ site.env.AUTHOR_NAME }}]]></name>
 					{% endif %}
 					{% if site.env.AUTHOR_EMAIL %}
 						<email>{{ site.env.AUTHOR_EMAIL }}</email>


### PR DESCRIPTION
This pull request contains one new feature and some smaller fixes.

The new feature allows the user to add a meta tag to the page, preventing the photo-stream being indexed by crawlers.
It can be turned on by setting the environment variable ALLOW_INDEXING to 0 and adds the meta tag named `robots` to the header section of the html document. This options defaults to 1, so crawlers are allowed.

Fixes:
- Added cdata content to some fields in the rss feed xml to have a valid xml.
- There was a link in the readme referring to the old repo. I have replaced it with a relative link to the current repo.
- The meta url tag contained the url detected by the application. That url was wrong when using a reverse proxy. Now it uses the environment configuration url.