### PR TITLE
possible fix for translation in chrome, improvement for touchable devices

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,6 @@
 <head>
 	<meta charset="utf-8">
+	<meta name="google" content="notranslate" />
 	<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 	{% if site.env.ALLOW_INDEXING == "0" %}
 	<meta name="robots" content="noindex" />

--- a/css/master.scss
+++ b/css/master.scss
@@ -236,7 +236,9 @@ body {
 
 				.gridview-button {
 					@include button;
-					visibility: hidden;
+					@media not all and (hover: none) {
+						visibility: hidden;
+					}
 					background-color: rgba(200, 200, 200, .5);
 
 					&:focus,

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 ---
 
 <!doctype html>
-<html>
+<html class="notranslate" translate="no">
 {% include head.html %}
 <body>
 	{% assign target = "target" %}


### PR DESCRIPTION
Hello

in this pull request I have changed the css, so on touch devices with no possibility to hover, the buttons in the grid will always be visible. On Desktops with pointers, the buttons will only be visible by hovering over them.
Also I have added a new meta tag for translation policies and two attributes to the html tag. In my dev environment and my selfhosted instance, it supresses the chrome translation popup for dutch #20.
Lets see if it works for others too. :)