### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - INSTAGRAM_USERNAME=${INSTAGRAM_USERNAME}
       - ALLOW_ORIGINAL_DOWNLOAD=${ALLOW_ORIGINAL_DOWNLOAD}
     volumes:
-      - ${PHOTO_PATH}:/photo-stream/photos/original
+      - ${PHOTO_PATH}:/photo-stream/photos
     env_file: .env
     ports:
       - "4000:4000"


### PR DESCRIPTION
Corrected volume path. Previously it mapped photos dir to photos/original, so the result was in the container a dir structure that goes photos/original/original. So the photos from the volume landed in photos/original/original and not in photos/originals. That is why there was an error saying that there are no images found.