### PR TITLE
Add option to reverse image sort by default

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,9 @@ ALLOW_ORIGINAL_DOWNLOAD=0
 ALLOW_INDEXING=1
 ALLOW_IMAGE_SHARING=1
 PHOTO_PATH=./photos
+# Default sort order is newest to oldest images. Setting the following
+# to 1 will reverse this sort order and show oldest images first.
+DEFAULT_REVERSE_SORT=0
 # leave the following blank to disable
 TWITTER_USERNAME=
 GITHUB_USERNAME=maxvoltar

--- a/index.html
+++ b/index.html
@@ -7,7 +7,11 @@
 <body>
 	{% assign target = "target" %}
 	<ul class="grid" id="{{ target }}">
-		{% assign images = page.images | default: site.static_files | photo_filter %}
+		{% if site.env.DEFAULT_REVERSE_SORT == "1" %}
+			{% assign images = page.images | default: site.static_files | photo_filter | reverse %}
+		{% else %}
+			{% assign images = page.images | default: site.static_files | photo_filter %}
+		{% endif %}
 		{% include photos.html %}
 		</ul>
 		<ul class="links bottom">


### PR DESCRIPTION
Hi,

first of all thank you for this project, I really like the minimal approach of the gallery which take away the need for a bloated backend, user management or database. I just started using the project and stumbled upon the exact issue mentioned in Issue #42. The proposed JS "hack" worked kinda wonky for me and at least in Safari I had some quick sort-changes during loading the page and it did not always end up in the correct sort order I intended. Therefore I would like to propose the change in this MR.

This MR will add a new variable in the `.env` file called `DEFAULT_REVERSE_SORT` which when set to 1 will add the [liquid reverse filter](https://shopify.github.io/liquid/filters/reverse/) to the images array assignment inside the `index.html`. This allows the templates to stay clean of any filters, keeping the logic in the index file without the need to change the JavaScript which might behave different for each browser.

This change was tested with both variable values set using the docker-compose file building locally and it worked at least on my machine as intended.

Let me know if you see any improvements which can be done to that approach or if you want any other variable naming.