### PR TITLE
Added condition to load Toastify library only if enabled

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,7 +22,9 @@
 	<meta name="description" content="{{ site.env.DESCRIPTION }}">
 	<script type="text/javascript" src="{{ '/js/lazy-loading.js' | relative_url }}"></script>
 	<link rel="stylesheet" type="text/css" media="screen" href="{{ '/css/master.css' | relative_url }}" />
+	{% if site.env.ALLOW_IMAGE_SHARING == "1" %}
 	<link rel="stylesheet" type="text/css" href="{{ '/css/toastify.min.css' | relative_url }}">
+	{% endif %}
 	<link rel="shortcut icon" type="image/svg+xml" href="{{ '/favicon.svg' | relative_url }}" />
 	<link rel="shortcut icon" type="image/png" href="{{ '/favicon.png' | relative_url }}" />
 	<link rel="apple-touch-icon" href="touch-icon-iphone.png" />

--- a/index.html
+++ b/index.html
@@ -38,7 +38,9 @@
 			{% endif %}
 		</ul>
 		{% include javascript.html %}
+		{% if site.env.ALLOW_IMAGE_SHARING == "1" %}
 		<script type="text/javascript" src="{{ '/js/toastify.js' | relative_url }}"></script>
+		{% endif %}
 		{% if page.image_slug %}
 			<script src="{{ '/js/photos.js' | relative_url }}" data-photo-id="{{ page.image_slug }}" data-photo-url="{{ page.image_slug | relative_url }}" data-target-id="{{ target }}"></script>
 		{% endif %}


### PR DESCRIPTION
Today, CSS and JS Toastify files are loaded each time. Even if `ALLOW_IMAGE_SHARING` is disabled. 